### PR TITLE
Refactor get_domain_from_fqdn regex to handle both www and root domain

### DIFF
--- a/ionos_dyndns.py
+++ b/ionos_dyndns.py
@@ -136,7 +136,7 @@ def main():
 
 def get_domain_from_fqdn(fqdn):
     # Place the hyphen at the start of the character class to avoid misinterpretation
-    regex = r"(?:(?:[\w-]+)\.)+([\w-]+\.\w+)$"
+    regex = r"(?:(?:[\w-]+)\.)?([\w-]+\.\w+)$"
     match = re.search(regex, fqdn, re.IGNORECASE)
     return match.group(1) if match else None
 


### PR DESCRIPTION
This commit addresses an issue where the script was expecting the domain to include the "www" prefix for proper zone identification. The regex in get_domain_from_fqdn has been modified to make the subdomain part optional, allowing it to handle both domains with "www" and root domains without "www".

These changes were necessary to ensure the script works seamlessly with both www and root domains, providing more flexibility in DNS record handling.

Testing has been performed, and the script now successfully identifies and updates DNS records for domains with or without the "www" prefix.