### PR TITLE
Adding support for managing subdomain records

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ optional arguments:
   -H , --fqdn        Host's FQDN (Default: hostname -f)
   --api-prefix       API key publicprefix
   --api-secret       API key secret
+  -S, --subdomain    Create/Update subdomain A/AAAA record (Default: False)
 ```
 
 ## Ideas / To-do


### PR DESCRIPTION
**Description:**
This Pull Request adds a new feature to the `ionos_dyndns.py` script, allowing it to manage DNS records for subdomains. The feature has been added to address a specific need in my environment, and can be activated using the `--subdomain` option when running the script.

**Changes Made:**
- Added a `--subdomain` option to the script's command-line arguments.
- Modified the script's behavior to handle records for subdomains when the `--subdomain` option is enabled.
- Added comments and logging messages to improve code readability and maintainability.

**Reason for the Change:**
I forked this project to address a specific need in my infrastructure, where I needed to manage DNS records for multiple subdomains. This change adds a useful feature that may benefit other users of the project.
