### PR TITLE
Adding support for managing wildcard records

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ chmod +x ionos_dyndns.py
 
 ### General
 ```
-usage: ionos_dyndns.py [-h] [-4] [-6] [-i] [-H] --api-prefix  --api-secret
+usage: ionos_dyndns.py [-h] [-4] [-6] [-i] [-H] [-W] --api-prefix  --api-secret
 
 Create and update DNS records for this host using IONOS' API to use as a sort of DynDNS (for example via a cronjob).
 
@@ -50,6 +50,7 @@ optional arguments:
   -6, --AAAA         Create/Update AAAA record
   -i , --interface   Interface name for determining the public IPv6 address (Default: eth0)
   -H , --fqdn        Host's FQDN (Default: hostname -f)
+  -W --wildcard      Create/Update Wildcard A/AAAA record (Default: False)
   --api-prefix       API key publicprefix
   --api-secret       API key secret
 ```


### PR DESCRIPTION
**Description:**
This Pull Request adds a new feature to the `ionos_dyndns.py` script, allowing it to manage DNS Wildcard records . The feature has been added to address a specific need in my environment, and can be activated using the `--wildcard` option when running the script.

**Changes Made:**
- Added a `--wildcard` option to the script's command-line arguments.
- Modified the script's behavior to handle records for subdomains when the `--wildcard` option is enabled.
- Added comments and logging messages to improve code readability and maintainability.

**Reason for the Change:**
I forked this project to address a specific need in my infrastructure, where I needed to manage DNS records for multiple subdomains / wildcard. This change adds a useful feature that may benefit other users of the project.

**Potential Impact:**
This change does not affect the existing functionality of the script and introduces no notable side effects. It simply offers an additional feature for those who need to manage DNS wildcard records .
